### PR TITLE
Feat/es volume step

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/config/system/configs/system.cfg
+++ b/projects/ROCKNIX/packages/rocknix/config/system/configs/system.cfg
@@ -22,6 +22,7 @@ audio.display_titles=1
 audio.persystem=0
 audio.preamp=50
 audio.volume=60
+audio.volume.step=5
 boot=Emulationstation
 c128.integerscale=0
 c16.integerscale=0

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/volume
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/volume
@@ -9,9 +9,10 @@
 . /etc/profile.d/001-functions
 
 VOLUME=$(get_setting "audio.volume")
+STEP=$(get_setting "audio.volume.step")
 MAX_VOLUME=100
 MIN_VOLUME=0
-STEP=5
+
 
 case ${1} in
   "+"|"up")

--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="296aa02c6526ac42ebedb9ae9cab0062c3082b5f"
+PKG_VERSION="14e88d812efbdc1227868af4e2e23c9f63dbb89d"
 PKG_GIT_CLONE_BRANCH="feat/volume-step"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/edemirkan/rocknix-emulationstation-next"

--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="f3b65b2546161128be67626fb156277106c00c04"
-PKG_GIT_CLONE_BRANCH="master"
+PKG_VERSION="296aa02c6526ac42ebedb9ae9cab0062c3082b5f"
+PKG_GIT_CLONE_BRANCH="feat/volume-step"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"
+PKG_SITE="https://github.com/edemirkan/rocknix-emulationstation-next"
 PKG_URL="${PKG_SITE}.git"
 PKG_DEPENDS_TARGET="boost toolchain SDL2 freetype curl freeimage bash rapidjson SDL2_mixer fping p7zip alsa vlc drm_tool pugixml"
 PKG_NEED_UNPACK="busybox"


### PR DESCRIPTION
## Summary
  
  Fix input_sense mangohud / game guide hotkeys on inputplumber platforms.
  
  Also add SM6115 to inputplumber platform list for yabasanshiro-sa.
  
  ## Testing
  
  Tested on my Odin 2
  
  ## Additional Context
  
  TODO - to fix properly, we should add an `INPUTPLUMBER` var to ROCKNIX build options.
  
  ---
  
  ### AI Usage
  
  **Did you use AI tools to help write this code?** NO
